### PR TITLE
updated to work with Realm 99.0 and SwiftFetchedResultsController 4.0

### DIFF
--- a/RealmSwiftNYTStories.podspec
+++ b/RealmSwiftNYTStories.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RealmSwiftNYTStories"
-  s.version      = "1.1"
+  s.version      = "1.2"
   s.summary      = "Ready-to-go JSON parsing of New York Times Top Stories API into Realm Swift models"
   s.description  = <<-DESC
 Loads data from New York Times Top Stories API and parses the JSON into provided Realm Swift models.
@@ -9,10 +9,10 @@ Loads data from New York Times Top Stories API and parses the JSON into provided
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Adam Fish" => "af@realm.io" }
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/bigfish24/RealmNYTStories.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/DramaFever/RealmNYTStories.git", :tag => "v#{s.version}" }
   s.source_files  = "swift/*.{swift}"
   s.requires_arc = true
-  s.dependency "SwiftFetchedResultsController", ">= 2.4.1"
-  s.dependency "RealmSwift", ">= 0.96.0"
+  s.dependency "SwiftFetchedResultsController", ">= 4.0"
+  s.dependency "RealmSwift", ">= 0.99.0"
 
 end

--- a/swift/NYTStory.swift
+++ b/swift/NYTStory.swift
@@ -179,7 +179,7 @@ public class NYTStory: Object {
                             
                             for storyJSON in results {
                                 if let story = NYTStory.story(storyJSON) {
-                                    aRealm.addWithNotification(story, update: true)
+                                    aRealm.add(story, update: true)
                                 }
                             }
                             try! aRealm.commitWrite()


### PR DESCRIPTION
Basically, "addWithNotifications" is obsolete (and removed, not deprecated). Since fine-grained notifications are now in Realm, and by extension SwiftFetchedResultsController, the call to "addWithNotifications" can be changed to just "add".

P.S. - Before merging in, please change the "source" line in the podspec back to bigfish24.
